### PR TITLE
fix: use GITHUB_TOKEN out-of-the-box

### DIFF
--- a/gh-cleanup-notifications
+++ b/gh-cleanup-notifications
@@ -7,4 +7,6 @@ if ! type -p node >/dev/null; then
    exit 1
 fi
 
+export GITHUB_TOKEN=$(gh auth token)
+
 exec node index.js "$@"


### PR DESCRIPTION
Previously, the user had to export the GITHUB_TOKEN to start using the extension.

This is now working out-of-the-box.