### PR TITLE
fix: gh cleanup-notifications can be run from any directory

### DIFF
--- a/gh-cleanup-notifications
+++ b/gh-cleanup-notifications
@@ -7,6 +7,8 @@ if ! type -p node >/dev/null; then
    exit 1
 fi
 
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 export GITHUB_TOKEN=$(gh auth token)
 
-exec node index.js "$@"
+exec node ${SCRIPT_DIR}/index.js "$@"


### PR DESCRIPTION
Without this, when run outside of the project directory, an error was raised because `index.js` was specified incorrectly:

```
$ gh cleanup-notifications --verbose --dry-run | ts
node:internal/modules/cjs/loader:1222
  throw err;
  ^

Error: Cannot find module '/Users/andrewendt/index.js
```