### PR TITLE
chore: disable commitlint rule "body-max-line-length"

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
     "eslint": "^9.14.0",
     "semantic-release": "^24.2.0"
   },
+  "commitlint": {
+    "rules": {
+      "body-max-line-length": [0, "always"]
+    }
+  },
   "release": {
     "plugins": [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
This makes Dependabot PRs with longer body lines pass. There is no need to enforce this rule right now.

A future option would be to disable commitlint for Dependabot commits entirely but that is a bit too much for now.