### PR TITLE
Rewrite cleanup code into rules that can be extended

### DIFF
--- a/lib/notification-reducer.js
+++ b/lib/notification-reducer.js
@@ -15,6 +15,35 @@ export class NotificationReducer {
     }, []);
   }
 
+  get builtinRules() {
+    return {
+      cleanupClosedPrs: {
+        match: {
+          "pull_request.state": [ "closed" ]
+        },
+        log: "%d notifications for closed PRs, marking as done…",
+        action: "mark-as-done"
+      },
+      cleanupReassignedPrs: {
+        match: {
+          "reason": [ "subscribed" ],
+          "pull_request.assignee": [ { 'anything-but': [ this.me, null ] } ]
+        },
+        log: "%d notifications for PRs assigned to someone else, unsubscribing…",
+        action: "unsubscribe"
+      },
+      cleanupReviewedPrs: {
+        match: {
+          "reason": [ "review_requested" ],
+          "pull_request.requested_reviewers": [ { empty: true } ],
+          "pull_request.requested_teams": [ { empty: true } ]
+        },
+        log: "%d notifications for PRs requesting and gotten reviews, unsubscribing…",
+        action: "unsubscribe"
+      }
+    }
+  }
+
   get notificationsForClosedPRs() {
     return this.notificationsWithPullRequests.filter(notification => notification.pull_request.state === "closed");
   }
@@ -29,6 +58,31 @@ export class NotificationReducer {
     return this.notificationsWithPullRequests.filter((notification) => {
       const pendingReviews = notification.pull_request.requested_reviewers.length + notification.pull_request.requested_teams.length;
       return notification.reason === "review_requested" && pendingReviews === 0
+    });
+  }
+
+  applyRules(...args) {
+    return this.notificationsWithPullRequests.filter(obj => {
+      return args.every(([path, values]) => {
+        const reduced = path.split('.').reduce((acc, current) => acc[current], obj);
+        const isStringOrNumber = (value) => ['string', 'number'].includes(typeof value);
+
+        if (values.every(isStringOrNumber)) {
+          return values.includes(reduced);
+        }
+        if (values[0]?.['anything-but']) {
+          return !values[0]?.['anything-but'].includes(reduced);
+        }
+        if (values[0]?.['empty']) {
+          if (Array.isArray(reduced)) {
+            return reduced.length === 0;
+          }
+
+          return (typeof reduced !== 'undefined');
+        }
+
+        throw new Error(`Unexpected values: ${JSON.stringify(values)}`);
+      });
     });
   }
 }

--- a/lib/notification-reducer.js
+++ b/lib/notification-reducer.js
@@ -44,23 +44,6 @@ export class NotificationReducer {
     }
   }
 
-  get notificationsForClosedPRs() {
-    return this.notificationsWithPullRequests.filter(notification => notification.pull_request.state === "closed");
-  }
-
-  get notificationsForReassignedPRs() {
-    return this.notificationsWithPullRequests.filter((notification) => {
-      return notification.reason === "subscribed" && notification.pull_request.assignee != this.me && notification.pull_request.assignee !== null
-    });
-  }
-
-  get notificationsForReviewedPRs() {
-    return this.notificationsWithPullRequests.filter((notification) => {
-      const pendingReviews = notification.pull_request.requested_reviewers.length + notification.pull_request.requested_teams.length;
-      return notification.reason === "review_requested" && pendingReviews === 0
-    });
-  }
-
   applyRules(...args) {
     return this.notificationsWithPullRequests.filter(obj => {
       return args.every(([path, values]) => {

--- a/test/reducer.js
+++ b/test/reducer.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach } from 'node:test';
 import { NotificationReducer } from '../lib/notification-reducer.js';
 
 import path from 'path';
@@ -84,4 +84,144 @@ describe('Reducer', async () => {
     assert.equal(reducer.notificationsForReviewedPRs.length, 1);
     assert.equal(reducer.notificationsForReviewedPRs[0].subject.url, "https://api.github.com/repos/babbel/terraform-aws-acm/pulls/21");
   });
+
+  describe('#applyRules', async () => {
+    let reducer;
+
+    beforeEach(async () => {
+      const notifications = await github.notifications();
+      reducer = new NotificationReducer({ notifications });
+      reducer.pullRequests = [ pr21, pr45 ];
+    });
+
+    it('matches a single condition', async() => {
+      const rule = {
+        match: {
+          "pull_request.state": [ "closed" ]
+        },
+      };
+
+      const matchedNotifications = reducer.applyRules(...Object.entries(rule.match));
+      assert.equal(matchedNotifications.length, 1);
+      assert.equal(matchedNotifications[0].pull_request.number, 21);
+    });
+
+    it('matches a single condition with multiple values', async() => {
+      const rule = {
+        match: {
+          "pull_request.state": [ "closed", "open" ]
+        },
+      };
+
+      const matchedNotifications = reducer.applyRules(...Object.entries(rule.match));
+      assert.equal(matchedNotifications.length, 2);
+      assert.equal(matchedNotifications[0].pull_request.number, 45);
+      assert.equal(matchedNotifications[1].pull_request.number, 21);
+    });
+
+    it('matches several conditions', async() => {
+      const rule = {
+        match: {
+          "reason": [ "subscribed" ],
+          "pull_request.assignee": [ 'jansiwy' ]
+        },
+      };
+
+      const matchedNotifications = reducer.applyRules(...Object.entries(rule.match));
+      assert.equal(matchedNotifications.length, 1);
+      assert.equal(matchedNotifications[0].pull_request.number, 45);
+    });
+
+    describe('supports anything-but', async() => {
+      it('works with single condition', async () => {
+        const rule = {
+          match: {
+            "pull_request.state": [ { 'anything-but': [ 'closed' ] } ]
+          },
+        };
+
+        const matchedNotifications = reducer.applyRules(...Object.entries(rule.match));
+        assert.equal(matchedNotifications.length, 1);
+        assert.equal(matchedNotifications[0].pull_request.number, 45);
+        assert.equal(matchedNotifications[0].pull_request.state, 'open');
+      });
+
+      it ('works in composite condition', async () => {
+        const rule = {
+          match: {
+            "reason": [ "subscribed" ],
+            "pull_request.assignee": [ { 'anything-but': [ null ] } ]
+          },
+        };
+
+        const matchedNotifications = reducer.applyRules(...Object.entries(rule.match));
+        assert.equal(matchedNotifications.length, 1);
+        assert.equal(matchedNotifications[0].pull_request.number, 45);
+        assert.equal(matchedNotifications[0].pull_request.assignee, 'jansiwy');
+      });
+    });
+
+    describe('supports empty', async() => {
+      it('checks for existence', async () => {
+        const rule = {
+          match: {
+            "pull_request.missing_key": [ { empty: true } ]
+          },
+        };
+
+        const matchedNotifications = reducer.applyRules(...Object.entries(rule.match));
+        assert.equal(matchedNotifications.length, 0);
+      });
+
+      it('finds empty arrays', async () => {
+        const rule = {
+          match: {
+            "reason": [ "review_requested" ],
+            "pull_request.requested_reviewers": [ { empty: true } ]
+          },
+        };
+
+        const matchedNotifications = reducer.applyRules(...Object.entries(rule.match));
+        assert.equal(matchedNotifications.length, 1);
+        assert.equal(matchedNotifications[0].pull_request.number, 21);
+        assert.equal(matchedNotifications[0].pull_request.requested_reviewers.length, 0);
+      });
+    });
+
+    it('returns closed PRs', async () => {
+      const rule = reducer.builtinRules.cleanupClosedPrs;
+      const prsWhereRulesApply = reducer.applyRules(...Object.entries(rule.match));
+      assert.equal(prsWhereRulesApply.length, 1);
+      assert.equal(prsWhereRulesApply[0].subject.url, "https://api.github.com/repos/babbel/terraform-aws-acm/pulls/21");
+    });
+
+    describe('reassigned PRs', async () => {
+      it('returns reassigned PRs for one person', async () => {
+        const rule = reducer.builtinRules.cleanupReassignedPrs;
+        const prsWhereRulesApply = reducer.applyRules(...Object.entries(rule.match));
+        assert.equal(prsWhereRulesApply.length, 1);
+        assert.equal(prsWhereRulesApply[0].subject.url, "https://api.github.com/repos/babbel/terraform-aws-athena/pulls/45");
+      });
+
+      it('returns no reassigned PRs for another person', async () => {
+        const reducer = new NotificationReducer({ notifications, me: 'jansiwy' });
+        reducer.pullRequests = [ pr21, pr45 ];
+
+        const rule = reducer.builtinRules.cleanupReassignedPrs;
+        const prsWhereRulesApply = reducer.applyRules(...Object.entries(rule.match));
+        assert.equal(prsWhereRulesApply.length, 0);
+      });
+    });
+
+    it('returns reviewed PRs', async () => {
+      const reducer = new NotificationReducer({ notifications });
+      reducer.pullRequests = [ pr21, pr45 ];
+
+      const rule = reducer.builtinRules.cleanupReviewedPrs;
+      const prsWhereRulesApply = reducer.applyRules(...Object.entries(rule.match));
+      assert.equal(prsWhereRulesApply.length, 1);
+      assert.equal(prsWhereRulesApply[0].subject.url, "https://api.github.com/repos/babbel/terraform-aws-acm/pulls/21");
+    });
+  });
+
 });

--- a/test/reducer.js
+++ b/test/reducer.js
@@ -59,32 +59,6 @@ describe('Reducer', async () => {
     ]);
   });
 
-  it('returns closed PRs #notificationsForClosedPRs', async () => {
-    const reducer = new NotificationReducer({ notifications });
-    reducer.pullRequests = [ pr21, pr45 ];
-
-    assert.equal(reducer.notificationsForClosedPRs.length, 1);
-    assert.equal(reducer.notificationsForClosedPRs[0].subject.url, "https://api.github.com/repos/babbel/terraform-aws-acm/pulls/21");
-  });
-
-  it('returns closed PRs #notificationsForReassignedPRs', async () => {
-    const notifications = await github.notifications();
-    const reducer = new NotificationReducer({ notifications, me: 'awendt' });
-    reducer.pullRequests = [ pr21, pr45 ];
-
-    assert.equal(reducer.notificationsForReassignedPRs.length, 1);
-    assert.equal(reducer.notificationsForReassignedPRs[0].subject.url, "https://api.github.com/repos/babbel/terraform-aws-athena/pulls/45");
-  });
-
-  it('returns closed PRs #notificationsForReviewedPRs', async () => {
-    const notifications = await github.notifications();
-    const reducer = new NotificationReducer({ notifications });
-    reducer.pullRequests = [ pr21, pr45 ];
-
-    assert.equal(reducer.notificationsForReviewedPRs.length, 1);
-    assert.equal(reducer.notificationsForReviewedPRs[0].subject.url, "https://api.github.com/repos/babbel/terraform-aws-acm/pulls/21");
-  });
-
   describe('#applyRules', async () => {
     let reducer;
 


### PR DESCRIPTION
> [!NOTE]
> This is a re-attempt of #32 (which didn't trigger a release by accident)

All 3 code paths for cleanup (`--cleanup-reviewed-prs`, `--cleanup-reassigned-prs`, `--cleanup-reviewed-prs`) are now generalized into rules.

This allows users to eventually extend the functionality.